### PR TITLE
Replaced counter-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,11 @@ const constContainer = #{
 
 const tuple = #[1, 2, 3];
 
-tuple.map(x => new MyClass(x));
-// TypeError: Expected value type as return
+tuple.with(0, new MyClass(tuple[0]));
+// TypeError: Can't assign a non-value type
 
 // The following should work:
-Array.from(tuple).map(x => new MyClass(x))
+Array.from(tuple)[0] = new MyClass(tuple[0]);
 ```
 
 # Syntax


### PR DESCRIPTION
There was a counter-example that references tuple.map. I didn't see that defined anywhere else and I think such a method would cause problems for typescript[1]. Because of these challenges I think it's best to just replace the example until a decision on how .map will work is reached.

[1]: My understanding is that `#[1, '2']` would have the type `Tuple<number, string>`. and so the callback function would either need the type `<U>(xs: number | string) => U` or need to only be applied to a specific value in the tuple (first?). If the former tactic is used then you lose the discrete type of the output when you need to map between types.

```
const foo = #{true, 1}.map(x => typeof x === 'boolean' ? false : x + 1)
```
results in `foo : Tuple<boolean | number, boolean | number>` when what is intended is likely `Tuple<boolean, number>`

